### PR TITLE
Move integration tests into a separate project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,8 +73,6 @@ val `oolong-mongo` = (project in file("oolong-mongo"))
   .settings(
     libraryDependencies ++= Seq(
       ("org.mongodb.scala" %% "mongo-scala-driver"             % "4.6.1"  % Test).cross(CrossVersion.for3Use2_13),
-      "com.dimafeng"       %% "testcontainers-scala-scalatest" % "0.40.8" % Test,
-      "com.dimafeng"       %% "testcontainers-scala-mongodb"   % "0.40.8" % Test,
       "org.scalatest"      %% "scalatest"                      % "3.2.12" % Test,
       "org.slf4j"           % "slf4j-api"                      % "1.7.36" % Test,
       "org.slf4j"           % "slf4j-simple"                   % "1.7.36" % Test,
@@ -82,9 +80,21 @@ val `oolong-mongo` = (project in file("oolong-mongo"))
     Test / fork := true
   )
 
+val `oolong-mongo-it` = (project in file("oolong-mongo-it"))
+  .settings(Settings.common)
+  .dependsOn(`oolong-mongo` % "test->test;compile->compile")
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.40.8" % Test,
+      "com.dimafeng" %% "testcontainers-scala-mongodb" % "0.40.8" % Test,
+    ),
+    Test / fork := true,
+    publish / skip := true
+  )
+
 val root = (project in file("."))
   .settings(Settings.common)
-  .aggregate(`oolong-bson`, `oolong-core`, `oolong-mongo`)
+  .aggregate(`oolong-bson`, `oolong-core`, `oolong-mongo`, `oolong-mongo-it`)
   .settings(
     pullRemoteCache := {},
     pushRemoteCache := {},

--- a/oolong-mongo-it/src/test/scala/oolong/mongo/OolongMongoSpec.scala
+++ b/oolong-mongo-it/src/test/scala/oolong/mongo/OolongMongoSpec.scala
@@ -1,29 +1,20 @@
 package oolong.mongo
 
-import java.util.concurrent.atomic.AtomicReference
-import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.Await
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.duration.*
-import scala.util.Failure
-import scala.util.Random
-import scala.util.Success
-
-import com.dimafeng.testcontainers.ForAllTestContainer
-import com.dimafeng.testcontainers.MongoDBContainer
-import oolong.bson.*
-import oolong.bson.given
+import com.dimafeng.testcontainers.{ForAllTestContainer, MongoDBContainer}
+import oolong.bson.{*, given}
 import oolong.dsl.*
 import oolong.mongo.MongoType
-import org.mongodb.scala.MongoClient
-import org.mongodb.scala.ObservableFuture
-import org.mongodb.scala.bson.BsonDocument
-import org.mongodb.scala.bson.BsonInt32
-import org.mongodb.scala.bson.BsonString
+import org.mongodb.scala.bson.{BsonDocument, BsonInt32, BsonString}
+import org.mongodb.scala.{MongoClient, ObservableFuture}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.compatible.Assertion
 import org.scalatest.flatspec.AsyncFlatSpec
+
+import java.util.concurrent.atomic.AtomicReference
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.duration.*
+import scala.util.{Failure, Random, Success}
 
 class OolongMongoSpec extends AsyncFlatSpec with ForAllTestContainer with BeforeAndAfterAll {
 


### PR DESCRIPTION
Original idea was to move them into `it` configuration, but since sbt 1.9.0 using of `IntegrationTest` is [deprecated](https://eed3si9n.com/sbt-1.9.0) and creating a separate project is encouraged instead.
