### PR TITLE
Fix parseFlags to handle constant-folded flag values

### DIFF
--- a/oolong-core/src/main/scala/oolong/Utils.scala
+++ b/oolong-core/src/main/scala/oolong/Utils.scala
@@ -143,6 +143,8 @@ private[oolong] object Utils:
               parseFlagsRec(term)(flags :+ mapNameToFlag(flag))
             case Select(term, "|")              => parseFlagsRec(term)(flags)
             case Select(Ident("Pattern"), flag) => flags :+ mapNameToFlag(flag)
+            case Literal(IntConstant(n)) =>
+              flags ++ (0 until 30).map(1 << _).filter(b => (n & b) != 0)
 
         parseFlagsRec(term)(List.empty)
 


### PR DESCRIPTION
### Problem

If the compiler constant-folds a flags expression (e.g. `Pattern.CASE_INSENSITIVE | Pattern.COMMENTS`) into a single IntConstant (e.g. `6`), `parseFlag` failed to match.

### Solution

This PR adds a case to decompose the constant back into individual flag bits.

### Notes

This issue was found while enhancing constant-folding in the Scala 3 compiler:

- PR: https://github.com/scala/scala3/pull/25731
- Issue: https://github.com/scala/scala3/issues/25697

### Checklist

- [x] Unit test all changes
- [x] Update `README.md` if applicable
- [x] Add `[WIP]` to the pull request title if it's work in progress
- [x] [Squash commits](https://ariejan.net/2011/07/05/git-squash-your-latests-commits-into-one) that aren't meaningful changes

@oolong/maintainers
