### PR TITLE
Fix publish artifacts step to trigger on tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         run: sbt test
 
       - name: Publish artifacts
-        if: github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}


### PR DESCRIPTION
## Summary

- The `Publish artifacts` step had `if: github.ref == 'refs/heads/main'`, which only matched branch pushes — tag-triggered builds (releases) were silently skipped
- Updated condition to `github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))`, matching the approach in [sbt-ci-release's own release.yml](https://github.com/sbt/sbt-ci-release/blob/master/.github/workflows/release.yml)
- The `github.event_name == 'push'` guard ensures secrets are never exposed during pull request builds

## Test plan

- [ ] Merge to `main` → snapshot published (existing behaviour, unchanged)
- [ ] Push a `v*` tag → release published to Maven Central via `sbt ci-release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)