### PR TITLE
Bump CI actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -20,7 +20,7 @@ jobs:
       - uses: sbt/setup-sbt@v1
 
       - name: Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v8
 
       - name: Check formatting
         run: sbt fixCheck


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v6
- `actions/setup-java` v4 → v5
- `coursier/cache-action` v6 → v8

GitHub is deprecating Node.js 20-based actions: they will be force-migrated to Node.js 24 on **June 2, 2026** and removed from runners on **September 16, 2026**.

## Test plan

- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)